### PR TITLE
fix: make IPython import optional for non-notebook environments

### DIFF
--- a/sentidict/wordshifts.py
+++ b/sentidict/wordshifts.py
@@ -1,5 +1,9 @@
-from IPython.display import publish_display_data
-from IPython import get_ipython
+try:
+    from IPython.display import publish_display_data
+    from IPython import get_ipython
+except ImportError:
+    publish_display_data = None
+    get_ipython = lambda: None  # noqa: E731
 from os.path import join, dirname
 import codecs
 from .utils import shift, copy_static_files


### PR DESCRIPTION
## Problem

`uv run pytest` fails locally at collection time with:

```
ImportError: No module named 'IPython'
```

This happens because `sentidict/wordshifts.py` unconditionally imports IPython at the top level:

```python
from IPython.display import publish_display_data
from IPython import get_ipython
```

But `ipython` is only in the `docs` optional dependency group — it's not installed in a normal `uv sync --all-extras` test environment (it's in `docs`, not `test`). So the entire `sentidict` package fails to import, meaning pytest can't collect a single test.

These IPython calls are only meaningful in a notebook/interactive context — they're used for inline display. There's no reason the library should be unimportable without IPython installed.

## Fix

Wrap the IPython imports in a `try/except ImportError` and set safe fallbacks. No behavior changes in notebook environments; everywhere else the module now imports cleanly.

**Before:** `ERROR collecting test/test.py — ModuleNotFoundError: No module named 'IPython'`
**After:** `14 passed, 14 warnings`