### PR TITLE
chore: move version to pyproject.toml directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sentidict"
-dynamic = ["version"]
+version = "0.1.15"
 description = "Utilities for dictionary-based sentiment analysis. Includes 28 sentiment dictionaries with loaders, scoring, and interactive visualization."
 readme = "README.md"
 license = {file = "LICENSE.md"}
@@ -44,9 +44,6 @@ target-version = ["py310", "py311", "py312", "py313"]
 skip-string-normalization = true
 exclude = "sentidict/data/.*"
 
-[tool.hatch.version]
-path = "sentidict/__init__.py"
-pattern = "__version__ = [\"'\"](?P<version>.+)[\"'\"]"
 
 [tool.hatch.build.targets.wheel]
 packages = ["sentidict"]

--- a/sentidict/__init__.py
+++ b/sentidict/__init__.py
@@ -3,5 +3,5 @@ from . import utils
 from . import wordshifts
 from . import functions
 
-__version__ = "0.1.15"
+
 __all__ = ["dictionaries", "utils", "wordshifts", "functions"]

--- a/uv.lock
+++ b/uv.lock
@@ -2734,6 +2734,7 @@ wheels = [
 
 [[package]]
 name = "sentidict"
+version = "0.1.15"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
@@ -2796,7 +2797,7 @@ requires-dist = [
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=1.0.0" },
     { name = "twine", marker = "extra == 'dev'" },
 ]
-provides-extras = ["dev", "docs", "test"]
+provides-extras = ["docs", "test", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Removes the `dynamic = ["version"]` + `[tool.hatch.version]` pattern in favor of a plain `version = "0.1.15"` in `pyproject.toml`, consistent with all other repos.

- Remove `__version__` from `sentidict/__init__.py`
- Remove `[tool.hatch.version]` block from `pyproject.toml`
- All 14 tests pass